### PR TITLE
fix: atualizar link do mock

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Requisitos:
 
 - Validar se o usuário tem saldo antes da transferência.
 
-- Antes de finalizar a transferência, deve-se consultar um serviço autorizador externo, use este mock para simular (https://run.mocky.io/v3/8fafdd68-a090-496f-8c9a-3442cf30dae6).
+- Antes de finalizar a transferência, deve-se consultar um serviço autorizador externo, use este mock para simular (https://run.mocky.io/v3/5794d450-d2e2-4412-8131-73d0293ac1cc).
 
 - A operação de transferência deve ser uma transação (ou seja, revertida em qualquer caso de inconsistência) e o dinheiro deve voltar para a carteira do usuário que envia. 
 


### PR DESCRIPTION
O antigo link de mock está fora do ar: 
https://run.mocky.io/v3/8fafdd68-a090-496f-8c9a-3442cf30dae6

Então acabei por criar um link novo, que contém o mesmo corpo de resposta e código HTTP:
https://run.mocky.io/v3/5794d450-d2e2-4412-8131-73d0293ac1cc

Resposta:

```
{
  "message": "Autorizado"
}
```

Código HTTP: `200`

