### PR TITLE
feature: atualizar links de mocks do README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,15 +65,17 @@ A seguir estão algumas regras de negócio que são importantes para o funcionam
 
 - Validar se o usuário tem saldo antes da transferência;
 
-- Antes de finalizar a transferência, deve-se consultar um serviço autorizador externo, use este mock para
-  simular (https://run.mocky.io/v3/5794d450-d2e2-4412-8131-73d0293ac1cc);
+- Antes de finalizar a transferência, deve-se consultar um serviço autorizador externo, use este mock
+  [https://util.devi.tools/api/v2/authorize](https://util.devi.tools/api/v2/authorize) para simular o serviço
+  utilizando o verbo `GET`;
 
 - A operação de transferência deve ser uma transação (ou seja, revertida em qualquer caso de inconsistência) e o
   dinheiro deve voltar para a carteira do usuário que envia;
 
 - No recebimento de pagamento, o usuário ou lojista precisa receber notificação (envio de email, sms) enviada por um
-  serviço de terceiro e eventualmente este serviço pode estar indisponível/instável. Use este mock para simular o
-  envio (https://run.mocky.io/v3/54dc2cf1-3add-45b5-b5a9-6bf7e7f1f4a6);
+  serviço de terceiro e eventualmente este serviço pode estar indisponível/instável. Use este mock
+  [https://util.devi.tools/api/v1/notify)](https://util.devi.tools/api/v1/notify)) para simular o envio da notificação
+  utilizando o verbo `POST`;
 
 - Este serviço deve ser RESTFul.
 


### PR DESCRIPTION
### Problema

Os links do mocky vem expirando e temos tido que renová-los de tempos em tempos. Estes links não vão expirar.

### Objetivo

Utilizar links que simulam serviços externos que não expirem.